### PR TITLE
fix: align Binance Futures SDK dependencies

### DIFF
--- a/.github/workflows/supply-chain-security.yml
+++ b/.github/workflows/supply-chain-security.yml
@@ -123,7 +123,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          docker build --pull --file docker/backend.Dockerfile --tag trading-bot-service:supply-chain .
+          for attempt in 1 2 3; do
+            if docker build --pull --file docker/backend.Dockerfile --tag trading-bot-service:supply-chain .; then
+              exit 0
+            fi
+
+            if [[ "$attempt" == "3" ]]; then
+              exit 1
+            fi
+
+            sleep "$((attempt * 10))"
+          done
 
       - name: Audit service container image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/Languages/Python/pyproject.toml
+++ b/Languages/Python/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = [
     "pandas==2.3.2; python_version < '3.11'",
     "pandas==3.0.2; python_version >= '3.11'",
     "requests==2.34.2",
-    "binance-sdk-derivatives-trading-usds-futures==9.1.0",
-    "binance-sdk-derivatives-trading-coin-futures==5.2.0",
-    "binance-sdk-spot==8.1.0",
+    "binance-sdk-derivatives-trading-usds-futures==13.0.0",
+    "binance-sdk-derivatives-trading-coin-futures==9.0.0",
+    "binance-sdk-spot==10.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Replaces the broken standalone Coin Futures SDK update.\n\n- upgrades Coin Futures SDK to 9.0.0\n- upgrades USDs Futures SDK to 13.0.0\n- upgrades Spot SDK to 10.0.0\n\nAll three share binance-common==4.0.3.\n\nVerified locally on Python 3.14: editable install with desktop/service/dev extras, pip check, direct SDK REST-client imports, Ruff, and 1,072 Python tests.